### PR TITLE
Update CODEOWNERS & fix caching.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jacobwilson41 @dmarkham
+* @wildlink/frontend

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         node: [12.13.1]
     container:
-      image: node:${{ matrix.node }}-alpine
+      image: node:${{ matrix.node }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
Update CODEOWNERS file to reflect the team that owns it. Fix caching key
for more consistent build dep cache.