### PR TITLE
update gh actions

### DIFF
--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -10,10 +10,10 @@ jobs:
       image: node:${{ matrix.node }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
update github actions versions to move away from deprecated node versions https://linear.app/wildfire-systems/project/gha-node-versions-update-6db851c28e2e/issues