### PR TITLE
[DSO-1381] Upgrade actions/cache to v5 and actions/setup-node to v6

### DIFF
--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -5,14 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 12.13.1
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Upgrades two GitHub Actions to their current versions in `.github/workflows/actions-test.yml`:

- `actions/cache`: v4 → v5
- `actions/setup-node`: v4 → v6

Linear: https://linear.app/wildfire-systems/issue/DSO-1381/backend-js-client